### PR TITLE
Patch vty-ui.cabal to have looser package dependencies

### DIFF
--- a/vty-ui.cabal
+++ b/vty-ui.cabal
@@ -75,10 +75,10 @@ Library
   Build-Depends:
     base >= 4 && < 5,
     vty >= 4.6 && < 4.7,
-    containers >= 0.2 && < 0.4,
+    containers >= 0.2 && < 0.5,
     pcre-light >= 0.3 && < 0.4,
-    directory >= 1.0 && < 1.1,
-    filepath >= 1.1 && < 1.2,
+    directory >= 1.0 && < 1.2,
+    filepath >= 1.1 && < 1.3,
     unix >= 2.4 && < 2.5,
     mtl >= 2.0 && < 2.1
 
@@ -155,7 +155,7 @@ Executable vty-ui-complex-demo
     base >= 4 && < 5,
     mtl >= 2.0 && < 2.1,
     bytestring >= 0.9 && < 1.0,
-    time >= 1.1 && < 1.2,
+    time >= 1.1 && < 1.3,
     old-locale >= 1.0 && < 1.1,
     pcre-light >= 0.3 && < 0.4,
     vty >= 4.6 && < 4.7


### PR DESCRIPTION
Hello,
This patch updates the version constraint for the following package dependencies: containers ; directory ; filepath ; time

Compiling with the demos works fine for me with this patch. I have not tried compiling for testing.

Cheers,
Corey O'Connor
