### PR TITLE
Successfully compiles against 0.4

### DIFF
--- a/vty-ui.cabal
+++ b/vty-ui.cabal
@@ -76,7 +76,7 @@ Library
     base >= 4 && < 5,
     vty >= 4.6 && < 4.7,
     containers >= 0.2 && < 0.5,
-    pcre-light >= 0.3 && < 0.4,
+    pcre-light >= 0.3 && < 0.5,
     directory >= 1.0 && < 1.2,
     filepath >= 1.1 && < 1.3,
     unix >= 2.4 && < 2.5,
@@ -157,7 +157,7 @@ Executable vty-ui-complex-demo
     bytestring >= 0.9 && < 1.0,
     time >= 1.1 && < 1.3,
     old-locale >= 1.0 && < 1.1,
-    pcre-light >= 0.3 && < 0.4,
+    pcre-light >= 0.3 && < 0.5,
     vty >= 4.6 && < 4.7
   if !flag(demos)
     Buildable: False


### PR DESCRIPTION
Compiled against pcre-light-0.4; update .cabal file to reflect this.
