### PR TITLE
Updates for ghc-7.4.1

### DIFF
--- a/vty-ui.cabal
+++ b/vty-ui.cabal
@@ -94,7 +94,7 @@ Library
     unix >= 2.4 && < 2.6,
     mtl >= 2.0 && < 2.1,
     stm >= 2.1 && < 2.3,
-    array >= 0.3 && < 0.4
+    array >= 0.3.0.0 && < 0.5.0.0
 
   GHC-Options:       -Wall
 
@@ -169,7 +169,7 @@ Executable vty-ui-complex-demo
     base >= 4 && < 5,
     mtl >= 2.0 && < 2.1,
     bytestring >= 0.9 && < 1.0,
-    time >= 1.1 && < 1.3,
+    time >= 1.1 && < 1.5,
     old-locale >= 1.0 && < 1.1,
     vty >= 4.6 && < 4.8
   if !flag(demos)


### PR DESCRIPTION
I've changed the **array** and **time** constraints to allow building with ghc-7.4.1.  Everything worked with cabal-dev, so I'm hoping that this is the only change necessary.  My testing process was:

``` bash
$ cabal-dev install-deps
$ cabal-dev configure
$ cabal-dev build
```
