### PR TITLE
ghc-7.6.1 compatibility

### DIFF
--- a/vty-ui.cabal
+++ b/vty-ui.cabal
@@ -90,13 +90,13 @@ Library
   Build-Depends:
     base >= 4 && < 5,
     vty >= 4.6 && < 4.8,
-    containers >= 0.2 && < 0.5,
+    containers >= 0.2 && < 0.6,
     regex-base >= 0.93 && < 0.94,
-    directory >= 1.0 && < 1.2,
+    directory >= 1.0 && < 1.3,
     filepath >= 1.1 && < 1.4,
-    unix >= 2.4 && < 2.6,
+    unix >= 2.4 && < 2.7,
     mtl >= 2.0 && < 2.2,
-    stm >= 2.1 && < 2.3,
+    stm >= 2.1 && < 2.5,
     array >= 0.3.0.0 && < 0.5.0.0,
     text >= 0.11,
     vector >= 0.9
@@ -136,7 +136,7 @@ Library
 Executable vty-ui-tests
   Build-Depends:
     base >= 4 && < 5,
-    QuickCheck >= 2.4 && < 2.5,
+    QuickCheck >= 2.4 && < 2.6,
     random >= 1.0,
     text,
     vty,


### PR DESCRIPTION
Relax dependencies constraints to build with ghc-7.6.1 too.
