### PR TITLE
Only show cursor in widgets that need it

### DIFF
--- a/src/Graphics/Vty/Widgets/Borders.hs
+++ b/src/Graphics/Vty/Widgets/Borders.hs
@@ -75,6 +75,7 @@ hBorder = do
   wRef <- newWidget initSt $ \w ->
       w { growHorizontal_ = const $ return True
         , render_ = renderHBorder
+        , getCursorPosition_ = const $ return Nothing
         }
   return wRef
 
@@ -125,6 +126,7 @@ vBorder = do
   let initSt = VBorder def_attr
   wRef <- newWidget initSt $ \w ->
       w { growVertical_ = const $ return True
+        , getCursorPosition_ = const $ return Nothing
         , render_ = \this s ctx -> do
                    VBorder attr <- getState this
                    let attr' = mergeAttrs [ overrideAttr ctx

--- a/src/Graphics/Vty/Widgets/Centering.hs
+++ b/src/Graphics/Vty/Widgets/Centering.hs
@@ -51,6 +51,10 @@ hCentered ch = do
               let (half, _) = centered_halves region_width s (region_width chSz)
                   chPos = pos `plusWidth` half
               setCurrentPosition child chPos
+
+        , getCursorPosition_ = \this -> do
+              HCentered child <- getState this
+              getCursorPosition child
         }
   wRef `relayKeyEvents` ch
   wRef `relayFocusEvents` ch
@@ -90,6 +94,10 @@ vCentered ch = do
               let (half, _) = centered_halves region_height s (region_height chSz)
                   chPos = pos `plusHeight` half
               setCurrentPosition child chPos
+
+        , getCursorPosition_ = \this -> do
+              VCentered child <- getState this
+              getCursorPosition child
         }
   wRef `relayKeyEvents` ch
   wRef `relayFocusEvents` ch

--- a/src/Graphics/Vty/Widgets/Fills.hs
+++ b/src/Graphics/Vty/Widgets/Fills.hs
@@ -29,6 +29,8 @@ vFill c = do
                                           , normalAttr ctx
                                           ]
                    return $ char_fill attr' ch (region_width s) (region_height s)
+
+        , getCursorPosition_ = const $ return Nothing
         }
   return wRef
 
@@ -48,5 +50,7 @@ hFill c h = do
                                           , normalAttr ctx
                                           ]
                    return $ char_fill attr' ch (region_width s) (toEnum height)
+
+        , getCursorPosition_ = const $ return Nothing
         }
   return wRef

--- a/src/Graphics/Vty/Widgets/Fixed.hs
+++ b/src/Graphics/Vty/Widgets/Fixed.hs
@@ -49,6 +49,10 @@ hFixed fixedWidth child = do
             \this pos -> do
               HFixed _ ch <- getState this
               setCurrentPosition ch pos
+
+        , getCursorPosition_ = \this -> do
+              HFixed _ ch <- getState this
+              getCursorPosition ch
         }
   wRef `relayKeyEvents` child
   wRef `relayFocusEvents` child
@@ -82,6 +86,10 @@ vFixed maxHeight child = do
             \this pos -> do
               VFixed _ ch <- getState this
               setCurrentPosition ch pos
+
+        , getCursorPosition_ = \this -> do
+              VFixed _ ch <- getState this
+              getCursorPosition ch
         }
   wRef `relayKeyEvents` child
   wRef `relayFocusEvents` child

--- a/src/Graphics/Vty/Widgets/Limits.hs
+++ b/src/Graphics/Vty/Widgets/Limits.hs
@@ -46,6 +46,10 @@ hLimit maxWidth child = do
             \this pos -> do
               HLimit _ ch <- getState this
               setCurrentPosition ch pos
+
+        , getCursorPosition_ = \this -> do
+              HLimit _ ch <- getState this
+              getCursorPosition ch
         }
   wRef `relayKeyEvents` child
   wRef `relayFocusEvents` child
@@ -73,6 +77,10 @@ vLimit maxHeight child = do
             \this pos -> do
               VLimit _ ch <- getState this
               setCurrentPosition ch pos
+
+        , getCursorPosition_ = \this -> do
+              VLimit _ ch <- getState this
+              getCursorPosition ch
         }
   wRef `relayKeyEvents` child
   wRef `relayFocusEvents` child

--- a/src/Graphics/Vty/Widgets/Padding.hs
+++ b/src/Graphics/Vty/Widgets/Padding.hs
@@ -153,6 +153,9 @@ padded ch padding = do
 
               setCurrentPosition child newPos
 
+        , getCursorPosition_ = \this -> do
+              Padded child _ <- getState this
+              getCursorPosition child
         }
 
   wRef `relayKeyEvents` ch

--- a/src/Graphics/Vty/Widgets/ProgressBar.hs
+++ b/src/Graphics/Vty/Widgets/ProgressBar.hs
@@ -52,6 +52,7 @@ newProgressBar completeAttr incompleteAttr = do
           w { growHorizontal_ = const $ return True
             , render_ =
                 \this size ctx -> renderProgressBar size ctx =<< getState this
+            , getCursorPosition_ = const $ return Nothing
             }
 
   setProgress wRef 0


### PR DESCRIPTION
Hides the cursor in static widgets like borders or texts. Also,
container widgets like padding or centering now show the cursor
only if their clients would.
