### PR TITLE
Report correct item position in NewItemEvents

### DIFF
--- a/src/Graphics/Vty/Widgets/List.hs
+++ b/src/Graphics/Vty/Widgets/List.hs
@@ -269,7 +269,7 @@ insertIntoList list key w pos = do
                                    , scrollTopIndex = newScrollTop
                                    }
 
-  notifyItemAddHandler list (numItems + 1) key w
+  notifyItemAddHandler list (min numItems pos) key w
 
   when (numItems == 0) $
        do


### PR DESCRIPTION
Adding an item to a list previously emitted a NewItemEvent with the new
size of the list as first parameter even though the documentation says:

``` haskell
-- |A new item was added to the list at _the specified position_ with
-- the specified value and widget.
data NewItemEvent a b = NewItemEvent Int a (Widget b)
```

So we now report the position of the new item instead of the list size.
