### PR TITLE
Minor List improvements.

### DIFF
--- a/src/Graphics/Vty/Widgets/List.hs
+++ b/src/Graphics/Vty/Widgets/List.hs
@@ -35,8 +35,8 @@ module Graphics.Vty.Widgets.List
     , clearList
     , setSelected
     -- ** List inspection
-    , indexOf
-    , indicesOf
+    , getFirstListIndexOf
+    , getListIndicesOf
     , getListSize
     , getSelected
     , getListItem
@@ -462,17 +462,17 @@ setSelected wRef newPos = do
     (-1) -> return ()
     curPos -> scrollBy wRef (newPos - curPos)
 
--- |Get the index of the internal item @a@ in the list
-indexOf :: (Eq a) => Widget (List a b) -> a -> IO (Maybe Int)
-indexOf wRef item = do
+-- |Get the first index of the internal item @a@ in the list
+getFirstListIndexOf :: (Eq a) => Widget (List a b) -> a -> IO (Maybe Int)
+getFirstListIndexOf wRef item = do
   list <- state <~ wRef
   return $ V.findIndex matcher (listItems list)
   where
     matcher = \(match, _) -> item == match
 
 -- |Get all indices where the internal item @a@ is in the list
-indicesOf :: (Eq a) => Widget (List a b) -> a -> IO [Int]
-indicesOf wRef item = do
+getListIndicesOf :: (Eq a) => Widget (List a b) -> a -> IO [Int]
+getListIndicesOf wRef item = do
   list <- state <~ wRef
   return $ V.toList $ V.findIndices matcher (listItems list)
   where


### PR DESCRIPTION
This contains two (of possibly more to follow) improvements to the List Widget.

The first is the inclusion of the indexOf function, which when given a `Widget List a b` an element of `a` where `a` belongs to the class `Eq`, returns the index of the list, at which the internal element a with it's accompanying widget is displayed.  This allows to lookup the position of an item in the list and select or scroll to that item.  Assuming one drives the list primarily by it's internal elements.

The second removes a check of `scrollWindowSize list == 0`.  This lead to the strange behavior of

``` haskell
lst <- newList black `on` yellow 1
forM_ ["A", "B", "C"] $ x -> 
  plainText (T.pack x) >>= addToList lst "unused"
lst `setSelected` 1
sel <- getSelected lst
-- At this point `sel` is `Just (0, ("unused", "A"))` and not
-- as expected `Just (1, ("unused", "B"))`
```

Thus the second commit allows to select an item of the list prior to it being displayed.
