### PR TITLE
manual: correct description of getListItem's return value

### DIFF
--- a/doc/ch4/List.tex
+++ b/doc/ch4/List.tex
@@ -110,7 +110,7 @@ the state of a \fw{List}:
   value, and widget of the currently-selected list item.
 \item \fw{getListItem} -- takes a \fw{Widget (List a b)} and an index
   and returns \fw{Nothing} if the \fw{List} has no item at the
-  specified index item or returns \fw{Just (pos, (val, widget))}
+  specified index item or returns \fw{Just (val, widget)}
   corresponding to the list index.
 \end{itemize}
 


### PR DESCRIPTION
Hi,

just noticed that the description of `getListItem` is out of date, instead of `Just (pos, (val, widget))` it returns `Just (val, widget)`.

``` haskell
getListItem :: Widget (List a b) -> Int -> IO (Maybe (ListItem a b))
type ListItem a b = (a, Widget b)
```

Best,
Markus
