### PR TITLE
Expand version bounds on filepath dependency to support GHC 7.10

### DIFF
--- a/vty-ui.cabal
+++ b/vty-ui.cabal
@@ -93,7 +93,7 @@ Library
     containers >= 0.2 && < 0.6,
     regex-base >= 0.93 && < 0.94,
     directory >= 1.0 && < 1.3,
-    filepath >= 1.1 && < 1.4,
+    filepath >= 1.1 && < 1.5,
     unix >= 2.4 && < 2.8,
     mtl >= 2.0 && < 2.3,
     stm >= 2.1 && < 2.5,


### PR DESCRIPTION
Built on GHC 7.8.3 and 7.10 RC 3