### PR TITLE
add an efficient way to add multiple items to a list at a time

### DIFF
--- a/doc/ch4/List.tex
+++ b/doc/ch4/List.tex
@@ -63,6 +63,16 @@ appropriate type:
 In addition, items may be inserted into a \fw{List} at any position with
 the \fw{insertIntoList} function.
 
+There are also functions to efficiently add or insert multiple items to a
+\fw{List}, namely \fw{addMultipleToList} and \fw{insertMultipleIntoList}. These
+functions take lists of pairs of the internal items and widgets:
+
+\begin{haskellcode}
+  let internalValues = ["foo", "bar", "baz"]
+  widgets <- mapM plainText internalValues
+  addMultipleToList lst (zip internalValues widgets)
+\end{haskellcode}
+
 When it comes to how \fw{List}s render item widgets, there are two behaviors to
 know about:
 

--- a/src/Graphics/Vty/Widgets/List.hs
+++ b/src/Graphics/Vty/Widgets/List.hs
@@ -264,7 +264,7 @@ insertMultipleIntoList list widgets pos = do
   oldScr <- scrollTopIndex <~~ list
   swSize <- scrollWindowSize <~~ list
 
-  let newSelIndex = if numItems == 0
+  let newSelIndex = if numItems == 0 && numNewItems > 0
                     then 0
                     else if pos <= oldSel
                          then oldSel + numNewItems

--- a/src/Graphics/Vty/Widgets/List.hs
+++ b/src/Graphics/Vty/Widgets/List.hs
@@ -241,9 +241,9 @@ addToList list key w = do
 
 -- |Add a list of items to the list.
 addMultipleToList :: (Show b) => Widget (List a b) -> [(a, Widget b)] -> IO ()
-addMultipleToList list widgets = do
+addMultipleToList list pairs = do
   numItems <- (V.length . listItems) <~~ list
-  insertMultipleIntoList list widgets numItems
+  insertMultipleIntoList list pairs numItems
 
 -- |Insert an element into the list at the specified position.  If the
 -- position exceeds the length of the list, it is inserted at the end.

--- a/src/Graphics/Vty/Widgets/List.hs
+++ b/src/Graphics/Vty/Widgets/List.hs
@@ -17,7 +17,9 @@ module Graphics.Vty.Widgets.List
     , newTextList
     , newList
     , addToList
+    , addMultipleToList
     , insertIntoList
+    , insertMultipleIntoList
     , removeFromList
     , setSelectedFocusedAttr
     , setSelectedUnfocusedAttr
@@ -231,19 +233,31 @@ setSelectedUnfocusedAttr :: Widget (List a b) -> Maybe Attr -> IO ()
 setSelectedUnfocusedAttr w attr = do
   updateWidgetState w $ \l -> l { selectedUnfocusedAttr = attr }
 
--- |Add an item to the list.  Its widget will be constructed from the
--- specified internal value using the widget constructor passed to
--- 'newList'.
+-- |Add an item to the list.
 addToList :: (Show b) => Widget (List a b) -> a -> Widget b -> IO ()
 addToList list key w = do
   numItems <- (V.length . listItems) <~~ list
   insertIntoList list key w numItems
 
+-- |Add a list of items to the list.
+addMultipleToList :: (Show b) => Widget (List a b) -> [(a, Widget b)] -> IO ()
+addMultipleToList list widgets = do
+  numItems <- (V.length . listItems) <~~ list
+  insertMultipleIntoList list widgets numItems
+
 -- |Insert an element into the list at the specified position.  If the
 -- position exceeds the length of the list, it is inserted at the end.
 insertIntoList :: (Show b) => Widget (List a b) -> a -> Widget b -> Int -> IO ()
-insertIntoList list key w pos = do
+insertIntoList list key w pos = insertMultipleIntoList list [(key, w)] pos
+
+-- |Insert a list of elements into the list at the specified position.  If the
+-- position exceeds the length of the list, they are inserted at the end.
+-- This is much more efficient than multiple calls to insertIntoList for very
+-- large lists of widgets.
+insertMultipleIntoList :: (Show b) => Widget (List a b) -> [(a, Widget b)] -> Int -> IO ()
+insertMultipleIntoList list widgets pos = do
   numItems <- (V.length . listItems) <~~ list
+  let numNewItems = length widgets
 
   -- Calculate the new selected index.
   oldSel <- selectedIndex <~~ list
@@ -253,33 +267,32 @@ insertIntoList list key w pos = do
   let newSelIndex = if numItems == 0
                     then 0
                     else if pos <= oldSel
-                         then oldSel + 1
+                         then oldSel + numNewItems
                          else oldSel
-      newScrollTop = if pos <= oldSel
-                     then if (oldSel - oldScr + 1) == swSize
-                          then oldScr + 1
-                          else oldScr
+      pastBottom = newSelIndex - oldScr - swSize
+      newScrollTop = if pos <= oldSel && pastBottom > 0
+                     then oldScr + pastBottom + 1
                      else oldScr
 
-  let vInject atPos a as = let (hd, t) = (V.take atPos as, V.drop atPos as)
-                           in hd V.++ (V.cons a t)
+  let vInject atPos new as = let (hd, t) = (V.take atPos as, V.drop atPos as)
+                           in hd V.++ new V.++ t
 
   -- Optimize the append case.
   let newItems s = if pos >= numItems
-                   then V.snoc (listItems s) (key, w)
-                   else vInject pos (key, w) (listItems s)
+                   then (listItems s) V.++ (V.fromList widgets)
+                   else vInject pos (V.fromList widgets) (listItems s)
 
   updateWidgetState list $ \s -> s { listItems = V.force $ newItems s
                                    , selectedIndex = newSelIndex
                                    , scrollTopIndex = newScrollTop
                                    }
 
-  notifyItemAddHandler list (min numItems pos) key w
+  mapM_ (uncurry $ notifyItemAddHandler list (min numItems pos)) widgets
 
-  when (numItems == 0) $
+  when (numItems == 0 && numNewItems > 0) $
        do
          foc <- focused <~ list
-         when foc $ focus w
+         when foc $ focus $ snd $ head widgets
 
   when (oldSel /= newSelIndex) $ notifySelectionHandler list
 


### PR DESCRIPTION
Fixes #68 

First, a caveat: this is my very first Haskell contribution. My knowledge of idioms and conventions is very poor. It'd be *very* helpful to me if someone checked over this code and either told me how it should be changed or just made changes directly, so I can learn how to better write Haskell :)

This PR introduces two new functions:

- `addMultipleToList :: (Show b) => Widget (List a b) -> [(a, Widget b)] -> IO ()`
- `insertMultipleIntoList :: (Show b) => Widget (List a b) -> [(a, Widget b)] -> Int -> IO ()`

These maybe aren't as fast as they could be but I can now pretty much instantly add the ~100k elements instead of waiting for 30 seconds to do it with repeated calls to `addToList`.

Couple of extra notes:
- I'm really bad at arithmetic, apparently, but I think I've simplified the `newScrollTop` calculation and maintained its behavior, which is "scroll *just* enough to keep the selected item in view". (now that I say that, maybe there should be a separate exposed function that does exactly that?)
- the `addToList` documentation mentioned something about constructing widgets based on a widget constructor passed to newList, which I guess was an old API or one that never got into master? I've gotten rid of that clause.
- I also added a bunch of features to the List Demo, mostly to make sure I got all the edge cases right, and to test performance. If this is too much for a simple demo, I'll be happy to revert that part of the PR.