### PR TITLE
Hide isSymbolicLink from directory

### DIFF
--- a/src/Graphics/Vty/Widgets/DirBrowser.hs
+++ b/src/Graphics/Vty/Widgets/DirBrowser.hs
@@ -31,7 +31,7 @@ import Graphics.Vty.Widgets.Box
 import Graphics.Vty.Widgets.Fills
 import Graphics.Vty.Widgets.Util
 import Graphics.Vty.Widgets.Events
-import System.Directory
+import System.Directory hiding (isSymbolicLink)
 import System.FilePath
 import System.Posix.Files
 import System.IO.Error


### PR DESCRIPTION
This was exposed in directory-1.2.6.0